### PR TITLE
Add offline setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,23 @@
 
 # Installation 
 
-See:  
-🚀 [Self-hosting](https://twenty.com/developers/section/self-hosting)  
-🖥️ [Local Setup](https://twenty.com/developers/local-setup)  
+See:
+🚀 [Self-hosting](https://twenty.com/developers/section/self-hosting)
+🖥️ [Local Setup](https://twenty.com/developers/local-setup)
+
+## Offline setup
+
+If your environment loses network access after the initial setup, make sure all
+dependencies are installed beforehand. Run the script below while network access
+is still available:
+
+```bash
+./scripts/setup-offline.sh
+```
+
+The script installs project dependencies with `yarn` and downloads Playwright
+browsers used by the E2E tests. After running it, subsequent commands can execute
+without requiring internet access.
 
 # Does the world need another CRM?
 

--- a/scripts/setup-offline.sh
+++ b/scripts/setup-offline.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing node dependencies..."
+yarn install --immutable
+
+echo "Installing Playwright browsers..."
+# this installs browsers required for E2E tests
+npx nx setup twenty-e2e-testing
+
+echo "All dependencies installed."


### PR DESCRIPTION
## Summary
- add `scripts/setup-offline.sh` to pre-install dependencies and browsers
- document offline setup procedure in README

## Testing
- `yarn --version` *(fails: fetch timeout because of no network)*