### PR TITLE
Add logistics objects for trucking industry

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
+++ b/packages/twenty-front/src/modules/object-metadata/components/NavigationDrawerSectionForObjectMetadataItems.tsx
@@ -12,6 +12,8 @@ const ORDERED_STANDARD_OBJECTS = [
   'opportunity',
   'task',
   'note',
+  'shipment',
+  'truck',
 ];
 
 export const NavigationDrawerSectionForObjectMetadataItems = ({

--- a/packages/twenty-server/src/engine/core-modules/search/constants/standard-objects-by-priority-rank.ts
+++ b/packages/twenty-server/src/engine/core-modules/search/constants/standard-objects-by-priority-rank.ts
@@ -4,5 +4,7 @@ export const STANDARD_OBJECTS_BY_PRIORITY_RANK = {
   company: 4,
   opportunity: 3,
   note: 2,
+  shipment: 3,
+  truck: 2,
   task: 1,
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -542,6 +542,29 @@ export const CUSTOM_OBJECT_STANDARD_FIELD_IDS = {
   searchVector: '70e56537-18ef-4811-b1c7-0a444006b815',
 };
 
+export const TRUCK_STANDARD_FIELD_IDS = {
+  name: '53b2d99c-0b46-490f-852c-0d2483b5d407',
+  licensePlate: '11277d1e-ad86-4665-a030-41cadcc60ae2',
+  capacity: '345f7bc1-7deb-4180-b863-e08935bddb52',
+  status: '2ffaa6f6-ef05-4a59-a8d5-892907506cd7',
+  shipments: '7766ec43-09a6-4bf2-8582-5c85de3e077f',
+  searchVector: '8d6123eb-52b8-47bb-8f69-5db7dd34e928',
+};
+
+export const SHIPMENT_STANDARD_FIELD_IDS = {
+  trackingNumber: '0189025c-67ad-42f6-bd82-7a0c3890657e',
+  originAddress: '5bb03a5a-8834-4a64-849b-e8c00d2caf7f',
+  destinationAddress: 'e0b97091-4c4a-46c9-b177-ec63234798d1',
+  weight: '5d95afa7-45f8-4ed4-9888-fce7bce5aa4e',
+  status: '877bad61-44cb-42f4-a35d-c8afe6ea2657',
+  company: 'f36a1ed8-0df6-4807-aee4-993ecf3969dd',
+  truck: 'e160c94e-b717-4a34-a893-da50aef7ebc8',
+  attachments: 'fd5c05b1-3ceb-4303-866e-f75f14882cbb',
+  timelineActivities: 'c225dc90-03fb-4277-8718-7ddcc7ab7bae',
+  createdBy: 'db9b4418-fadf-4709-91e3-1266687eb790',
+  searchVector: '77cc71d8-1d34-4199-acea-7f9be1713399',
+};
+
 export const STANDARD_OBJECT_FIELD_IDS = {
   activityTarget: ACTIVITY_TARGET_STANDARD_FIELD_IDS,
   activity: ACTIVITY_STANDARD_FIELD_IDS,
@@ -583,4 +606,6 @@ export const STANDARD_OBJECT_FIELD_IDS = {
   workflowRun: WORKFLOW_RUN_STANDARD_FIELD_IDS,
   workflowVersion: WORKFLOW_VERSION_STANDARD_FIELD_IDS,
   workspaceMember: WORKSPACE_MEMBER_STANDARD_FIELD_IDS,
+  truck: TRUCK_STANDARD_FIELD_IDS,
+  shipment: SHIPMENT_STANDARD_FIELD_IDS,
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons.ts
@@ -40,4 +40,6 @@ export const STANDARD_OBJECT_ICONS = {
   workflowVersion: 'IconVersions',
   workflowAutomatedTrigger: 'IconSettingsAutomation',
   workspaceMember: 'IconUserCircle',
+  truck: 'IconTruck',
+  shipment: 'IconPackage',
 };

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids.ts
@@ -50,4 +50,6 @@ export const STANDARD_OBJECT_IDS = {
   workflowVersion: '20202020-d65d-4ab9-9344-d77bfb376a3d',
   workspaceMember: '20202020-3319-4234-a34c-82d5c0e881a6',
   workflowAutomatedTrigger: '20202020-3319-4234-a34c-7f3b9d2e4d1f',
+  truck: '36376a0c-2e4e-407b-82cb-0cdf93db8520',
+  shipment: '82d1e164-2cf9-4420-bfb5-095ddd781fde',
 };

--- a/packages/twenty-server/src/modules/shipment/standard-objects/shipment.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/shipment/standard-objects/shipment.workspace-entity.ts
@@ -1,0 +1,184 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+
+import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/constants/search-vector-field.constants';
+import { AddressMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/address.composite-type';
+import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
+import {
+  FieldTypeAndNameMetadata,
+  getTsVectorColumnExpressionFromFields,
+} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
+import { SHIPMENT_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
+import { TruckWorkspaceEntity } from 'src/modules/truck/standard-objects/truck.workspace-entity';
+import { AttachmentWorkspaceEntity } from 'src/modules/attachment/standard-objects/attachment.workspace-entity';
+import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+
+const TRACKING_FIELD_NAME = 'trackingNumber';
+
+export const SEARCH_FIELDS_FOR_SHIPMENT: FieldTypeAndNameMetadata[] = [
+  { name: TRACKING_FIELD_NAME, type: FieldMetadataType.TEXT },
+];
+
+@WorkspaceEntity({
+  standardId: STANDARD_OBJECT_IDS.shipment,
+  namePlural: 'shipments',
+  labelSingular: msg`Shipment`,
+  labelPlural: msg`Shipments`,
+  description: msg`A shipment`,
+  icon: STANDARD_OBJECT_ICONS.shipment,
+})
+@WorkspaceIsSearchable()
+export class ShipmentWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.trackingNumber,
+    type: FieldMetadataType.TEXT,
+    label: msg`Tracking Number`,
+    description: msg`Shipment tracking number`,
+    icon: 'IconNumbers',
+  })
+  trackingNumber: string;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.originAddress,
+    type: FieldMetadataType.ADDRESS,
+    label: msg`Origin`,
+    description: msg`Shipment origin address`,
+    icon: 'IconMapPin',
+  })
+  @WorkspaceIsNullable()
+  originAddress: AddressMetadata | null;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.destinationAddress,
+    type: FieldMetadataType.ADDRESS,
+    label: msg`Destination`,
+    description: msg`Shipment destination address`,
+    icon: 'IconMapPin',
+  })
+  @WorkspaceIsNullable()
+  destinationAddress: AddressMetadata | null;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.weight,
+    type: FieldMetadataType.NUMBER,
+    label: msg`Weight`,
+    description: msg`Shipment weight`,
+    icon: 'IconWeight',
+  })
+  @WorkspaceIsNullable()
+  weight: number | null;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.status,
+    type: FieldMetadataType.SELECT,
+    label: msg`Status`,
+    description: msg`Shipment status`,
+    icon: 'IconPackage',
+    options: [
+      { value: 'PENDING', label: 'Pending', position: 0, color: 'gray' },
+      { value: 'IN_TRANSIT', label: 'In Transit', position: 1, color: 'blue' },
+      { value: 'DELIVERED', label: 'Delivered', position: 2, color: 'green' },
+    ],
+    defaultValue: "'PENDING'",
+  })
+  status: string;
+
+  @WorkspaceRelation({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.company,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Company`,
+    description: msg`Customer company`,
+    icon: 'IconBuildingSkyscraper',
+    inverseSideTarget: () => CompanyWorkspaceEntity,
+    inverseSideFieldKey: 'shipments',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  company: Relation<CompanyWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('company')
+  companyId: string | null;
+
+  @WorkspaceRelation({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.truck,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Truck`,
+    description: msg`Assigned truck`,
+    icon: 'IconTruck',
+    inverseSideTarget: () => TruckWorkspaceEntity,
+    inverseSideFieldKey: 'shipments',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  truck: Relation<TruckWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('truck')
+  truckId: string | null;
+
+  @WorkspaceRelation({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.attachments,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Attachments`,
+    description: msg`Shipment attachments`,
+    icon: 'IconFileImport',
+    inverseSideTarget: () => AttachmentWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  attachments: Relation<AttachmentWorkspaceEntity[]>;
+
+  @WorkspaceRelation({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.timelineActivities,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Timeline Activities`,
+    description: msg`Timeline activities linked to the shipment`,
+    icon: 'IconTimelineEvent',
+    inverseSideTarget: () => TimelineActivityWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  timelineActivities: Relation<TimelineActivityWorkspaceEntity[]>;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.createdBy,
+    type: FieldMetadataType.ACTOR,
+    label: msg`Created by`,
+    icon: 'IconCreativeCommonsSa',
+    description: msg`The creator of the record`,
+  })
+  createdBy: ActorMetadata;
+
+  @WorkspaceField({
+    standardId: SHIPMENT_STANDARD_FIELD_IDS.searchVector,
+    type: FieldMetadataType.TS_VECTOR,
+    label: SEARCH_VECTOR_FIELD.label,
+    description: SEARCH_VECTOR_FIELD.description,
+    icon: 'IconPackage',
+    generatedType: 'STORED',
+    asExpression: getTsVectorColumnExpressionFromFields(
+      SEARCH_FIELDS_FOR_SHIPMENT,
+    ),
+  })
+  @WorkspaceIsNullable()
+  @WorkspaceIsSystem()
+  @WorkspaceFieldIndex({ indexType: IndexType.GIN })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  searchVector: any;
+}

--- a/packages/twenty-server/src/modules/truck/standard-objects/truck.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/truck/standard-objects/truck.workspace-entity.ts
@@ -1,0 +1,118 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+
+import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/constants/search-vector-field.constants';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/index-metadata.entity';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
+import {
+  FieldTypeAndNameMetadata,
+  getTsVectorColumnExpressionFromFields,
+} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
+import { TRUCK_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { ShipmentWorkspaceEntity } from 'src/modules/shipment/standard-objects/shipment.workspace-entity';
+
+const NAME_FIELD_NAME = 'name';
+const LICENSE_PLATE_FIELD_NAME = 'licensePlate';
+
+export const SEARCH_FIELDS_FOR_TRUCK: FieldTypeAndNameMetadata[] = [
+  { name: NAME_FIELD_NAME, type: FieldMetadataType.TEXT },
+  { name: LICENSE_PLATE_FIELD_NAME, type: FieldMetadataType.TEXT },
+];
+
+@WorkspaceEntity({
+  standardId: STANDARD_OBJECT_IDS.truck,
+  namePlural: 'trucks',
+  labelSingular: msg`Truck`,
+  labelPlural: msg`Trucks`,
+  description: msg`A truck`,
+  icon: STANDARD_OBJECT_ICONS.truck,
+})
+@WorkspaceIsSearchable()
+export class TruckWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    standardId: TRUCK_STANDARD_FIELD_IDS.name,
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`Truck name`,
+    icon: 'IconTruck',
+  })
+  name: string;
+
+  @WorkspaceField({
+    standardId: TRUCK_STANDARD_FIELD_IDS.licensePlate,
+    type: FieldMetadataType.TEXT,
+    label: msg`License Plate`,
+    description: msg`Truck license plate`,
+    icon: 'IconLicense',
+  })
+  @WorkspaceIsNullable()
+  licensePlate: string | null;
+
+  @WorkspaceField({
+    standardId: TRUCK_STANDARD_FIELD_IDS.capacity,
+    type: FieldMetadataType.NUMBER,
+    label: msg`Capacity`,
+    description: msg`Truck capacity`,
+    icon: 'IconWeight',
+  })
+  @WorkspaceIsNullable()
+  capacity: number | null;
+
+  @WorkspaceField({
+    standardId: TRUCK_STANDARD_FIELD_IDS.status,
+    type: FieldMetadataType.SELECT,
+    label: msg`Status`,
+    description: msg`Truck status`,
+    icon: 'IconCircleCheck',
+    options: [
+      { value: 'AVAILABLE', label: 'Available', position: 0, color: 'green' },
+      { value: 'IN_USE', label: 'In Use', position: 1, color: 'blue' },
+      { value: 'MAINTENANCE', label: 'Maintenance', position: 2, color: 'orange' },
+    ],
+    defaultValue: "'AVAILABLE'",
+  })
+  status: string;
+
+  @WorkspaceRelation({
+    standardId: TRUCK_STANDARD_FIELD_IDS.shipments,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Shipments`,
+    description: msg`Shipments assigned to the truck`,
+    icon: 'IconPackage',
+    inverseSideTarget: () => ShipmentWorkspaceEntity,
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  shipments: Relation<ShipmentWorkspaceEntity[]>;
+
+  @WorkspaceField({
+    standardId: TRUCK_STANDARD_FIELD_IDS.searchVector,
+    type: FieldMetadataType.TS_VECTOR,
+    label: SEARCH_VECTOR_FIELD.label,
+    description: SEARCH_VECTOR_FIELD.description,
+    icon: 'IconTruck',
+    generatedType: 'STORED',
+    asExpression: getTsVectorColumnExpressionFromFields(
+      SEARCH_FIELDS_FOR_TRUCK,
+    ),
+  })
+  @WorkspaceIsNullable()
+  @WorkspaceIsSystem()
+  @WorkspaceFieldIndex({ indexType: IndexType.GIN })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  searchVector: any;
+}


### PR DESCRIPTION
## Summary
- extend standard object constants to include `truck` and `shipment`
- register icons for the new objects
- provide standard field IDs for trucks and shipments
- prioritize and display logistic objects in search and navigation
- implement `TruckWorkspaceEntity` and `ShipmentWorkspaceEntity`

## Testing
- `git status --short`